### PR TITLE
Change landing page title to 'Devfile'

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,11 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- braden-wilson
 - maysunfaisal
 - schultzp2020
+- johnmcollier
 
 reviewers:
-- braden-wilson
 - maysunfaisal
 - schultzp2020
+- johnmcollier

--- a/components/page/Meta.tsx
+++ b/components/page/Meta.tsx
@@ -35,7 +35,7 @@ const Meta: React.FC<MetaProps> = ({
 );
 
 Meta.defaultProps = {
-  title: 'devfiles',
+  title: 'Devfile',
   keywords: 'Devfile, OpenShift, Kubernetes',
   description: 'Devfile Landing Page'
 };


### PR DESCRIPTION
We discussed this on GChat a few weeks back and agreed on using `Devfile` instead of `devfiles`.

Also updates the OWNERS file.