### PR TITLE
docs: updating broken links

### DIFF
--- a/webpage_info/getting-started/2. Application Developer/2. Getting Started.adoc
+++ b/webpage_info/getting-started/2. Application Developer/2. Getting Started.adoc
@@ -2,8 +2,7 @@
 
 '''''
 
-*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html[Devfile
-specification]*
+*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference/[Devfile specification]*
 
 *Tools that provides devfile support:*
 

--- a/webpage_info/getting-started/3. Enterprise Architect and Runtime Provider/2. Getting Started.adoc
+++ b/webpage_info/getting-started/3. Enterprise Architect and Runtime Provider/2. Getting Started.adoc
@@ -2,9 +2,9 @@
 
 '''''
 
-*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html[Devfile specification]*
+*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference/[Devfile specification]*
 
-*https://docs.devfile.io/devfile/2.1.0/user-guide/authoring-stacks.html[Stack author’s guide documentation]*
+*https://docs.devfile.io/devfile/2.1.0/user-guide/authoring-devfiles/[Stack author’s guide documentation]*
 
 *https://github.com/devfile/registry/blob/main/CONTRIBUTING.md[Onboarding process and requirements of the community registry]*
 

--- a/webpage_info/getting-started/5. Technology and Tools Builders/2 . Getting Started.adoc
+++ b/webpage_info/getting-started/5. Technology and Tools Builders/2 . Getting Started.adoc
@@ -2,7 +2,7 @@
 
 '''''
 
-*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference.html[Devfile specification]*
+*https://docs.devfile.io/devfile/2.1.0/user-guide/api-reference/[Devfile specification]*
 
 *Detailed runtime behavior of the tools - coming soon*
 


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

**What does this PR do / why we need it**:

Updates dead links on the getting started page

**Which issue(s) this PR fixes**:

Fixes [#877](https://github.com/devfile/api/issues/877)

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [x] Documentation

**How to test changes / Special notes to the reviewer**:
- `yarn install`
- `yarn build`
- `yarn dev`
- manually check all links on the `Getting Started` page
